### PR TITLE
FEAT : 일일 공연 예매 순위 TOP 50 수집

### DIFF
--- a/dags/box_office_daily.py
+++ b/dags/box_office_daily.py
@@ -1,0 +1,142 @@
+import logging
+import requests
+import xml.etree.ElementTree as ET
+
+from datetime import datetime
+
+from airflow import DAG
+from airflow.operators.python import PythonOperator
+from airflow.models import Variable
+from airflow.providers.postgres.hooks.postgres import PostgresHook
+
+
+def get_Redshift_connection():
+    """ Redshift 연결 """
+    # autocommit is False by default
+    hook = PostgresHook(postgres_conn_id='redshift_dev_db')
+    conn = hook.get_conn()
+    return conn.cursor()
+
+def extract_transform(execution_date):
+    """ KOPIS 데이터 추출 및 XML -> [str] 으로 변환 """
+    logging.info(f"extract and transform started >> execution_date :{execution_date}")
+
+    box_office_url = Variable.get("box_office_url")
+    service_key = Variable.get("service_key")
+    url = f"{box_office_url}?service={service_key}&stdate={execution_date}&eddate={execution_date}"
+
+    response = requests.get(url)
+    xml_data = response.text.strip()
+    root = ET.fromstring(xml_data)
+
+    box_office_date = datetime.strptime(execution_date, '%Y%m%d').date()
+    result = []
+
+    for boxof in root.findall('boxof'):
+        ranking = boxof.find('rnum').text if boxof.find('rnum') is not None else None
+        performance_id = boxof.find('mt20id').text if boxof.find('mt20id') is not None else None
+        performance_name = boxof.find('prfnm').text if boxof.find('prfnm') is not None else None
+        genre = boxof.find('cate').text if boxof.find('cate') is not None else None
+        performance_count = boxof.find('prfdtcnt').text if boxof.find('prfdtcnt') is not None else None
+        area = boxof.find('area').text if boxof.find('area') is not None else None
+
+        if "'" in performance_name: # (e.g) Can't be blue
+            performance_name = performance_name.replace("'", "''")
+
+        result.append(f"('{box_office_date}',{ranking},'{performance_id}','{performance_name}','{genre}',{performance_count},'{area}')")
+
+    logging.info(f"extract and transform ended >> execution_date :{execution_date}")
+    return result
+
+def load(**context):
+    """ Redshift 데이터 적재 : Incremental Update"""
+    logging.info("load started")
+
+    schema = context["params"]["schema"]
+    table = context["params"]["table"]
+    records = context["task_instance"].xcom_pull(key="return_value", task_ids="extract_transform")
+
+    cur = get_Redshift_connection()
+
+    # 원본 테이블이 없으면 생성
+    create_table_sql = f"""
+        CREATE TABLE IF NOT EXISTS {schema}.{table} (
+            box_office_date date,
+            ranking int,
+            performance_id varchar(150),
+            performance_name varchar(255),
+            genre varchar(100),
+            performance_count int,
+            area varchar(100),
+            created_at timestamp default GETDATE()
+            );
+    """
+    logging.info(create_table_sql)
+
+    # 임시 테이블 생성
+    create_t_sql = f"""CREATE TEMP TABLE t AS SELECT * FROM {schema}.{table};"""
+    logging.info(create_t_sql)
+    try:
+        cur.execute(create_table_sql)
+        cur.execute(create_t_sql)
+        cur.execute("COMMIT;")
+    except Exception as e:
+        cur.execute("ROLLBACK;")
+        raise
+
+    # 임시 테이블 데이터 입력
+    insert_sql = f"INSERT INTO t VALUES " + ",".join(records)
+    logging.info(insert_sql)
+    try:
+        cur.execute(insert_sql)
+        cur.execute("COMMIT;")
+    except Exception as e:
+        cur.execute("ROLLBACK;")
+        raise
+
+    # 기존 테이블 대체
+    alter_sql = f"""
+        DELETE FROM {schema}.{table};
+        INSERT INTO {schema}.{table}
+        SELECT box_office_date, ranking, performance_id, performance_name, genre, performance_count, area FROM (
+            SELECT *, ROW_NUMBER() OVER (PARTITION BY box_office_date, performance_id, ranking ORDER BY created_at DESC) seq
+            FROM t
+        )
+        WHERE seq = 1;
+    """
+    logging.info(alter_sql)
+    try:
+        cur.execute(alter_sql)
+        cur.execute("COMMIT;")
+    except Exception as e:
+        cur.execute("ROLLBACK;")
+        raise   # TODO 슬랙 알림 추가
+
+    logging.info("load done")
+
+dag = DAG(
+    dag_id = 'Box_Office_Daily_v5',
+    start_date = datetime(2025,1,1),
+    catchup=True,
+    tags=['API'],
+    schedule = '0 0 * * *' # KST 오전 9시
+)
+
+extract_transform = PythonOperator(
+    task_id='extract_transform',
+    python_callable=extract_transform,
+    op_kwargs={
+        "execution_date": "{{execution_date.strftime('%Y%m%d')}}"
+    },
+    dag=dag)
+
+load = PythonOperator(
+    task_id='load',
+    python_callable=load,
+    params = {
+        'schema': 'soojiin_leee',
+        'table': 'box_office',
+    },
+    dag=dag)
+
+extract_transform >> load

--- a/dags/box_office_daily.py
+++ b/dags/box_office_daily.py
@@ -115,7 +115,7 @@ def load(**context):
     logging.info("load done")
 
 dag = DAG(
-    dag_id = 'Box_Office_Daily_v5',
+    dag_id = 'Box_Office_Daily_v6',
     start_date = datetime(2025,1,1),
     catchup=True,
     tags=['API'],
@@ -134,7 +134,7 @@ load = PythonOperator(
     task_id='load',
     python_callable=load,
     params = {
-        'schema': 'soojiin_leee',
+        'schema': 'raw_data',
         'table': 'box_office',
     },
     dag=dag)


### PR DESCRIPTION
# 작업 내용
## 1. Extract & Transform
- 공연 예술 통합 전산에서 제공하는 [예매 상황판 URL](https://www.kopis.or.kr/por/cs/openapi/openApiList.do?menuId=MNU_00074&tabId=tab2_1)을 통해 일일 예매 현황 데이터 수집
- 쿼리 파라미터로 사용 되는 예매 시작일(`stdate`)과 종료일(`eddate`)은 DAG의 `execution_date` 사용
- XML 데이터 중 Redshift 컬럼 타입에 맞게 데이터 변환

### 예매 상황판 API Response
```xml
<?xml version="1.0" encoding="UTF-8"?>
<boxofs>
    <boxof>
        <prfplcnm>블루스퀘어 신한카드홀(구. 인터파크홀)</prfplcnm>
        <seatcnt>1766</seatcnt>
        <rnum>1</rnum>
        <poster>http://www.kopis.or.kr/upload/pfmPoster/PF_PF250136_240930_134639.gif</poster>
        <prfpd>2024.11.29~2025.05.18</prfpd>
        <mt20id>PF250136</mt20id>
        <prfnm>지킬앤하이드</prfnm>
        <cate>뮤지컬</cate>
        <prfdtcnt>51</prfdtcnt>
        <area>서울</area>
    </boxof>
...
<boxofs>
```

## 2. Load 
- 수집한 데이터는 Incremental Update 방식으로 `Redshift`에 적재
### Redshift 테이블 명세서
| column                | type | xml tag  | 설명         |
|-----------------|------|---------|---------|
| box_office_date | date  |               | DAG 실행일(`execution_date`) |
| ranking                | int     | rnum     | 예매 순위 |
| performance_id  | varchar(150) | mt20id        | 공연 ID |
| performance_name  | varchar(255) | prfnm | 공연명 |
| genre                    | varchar(100)     | cate        | 공연 장르 |
| performance_count  | int     | prfdtcnt        | 공연 횟수 |
| area                      | varchar(100)     | area        | 공연 지역 |
| created_at           | timestamp default GETDATE()      |         | Redshift 적재일|

## 3. 실행 주기
- 매일 오전 9시 실행(KST)
